### PR TITLE
fix: keepalive页面下，将实际路由转化为小写

### DIFF
--- a/packages/keep-alive/src/utils/getKeepAliveLayout.tsx
+++ b/packages/keep-alive/src/utils/getKeepAliveLayout.tsx
@@ -90,7 +90,7 @@ export default class BasicLayout extends React.PureComponent<PageProps> {
                   right: 0,
                   bottom: 0,
                 }}
-                hidden={curPathname !== pathname}
+                hidden={curPathname !== pathname.toLowerCase()}
               >
                 <View {...this.props} />
               </div>


### PR DESCRIPTION
解决了在全小写正则配置keepalive路由参数时，实际页面路由含有大写字母，导致keepalive页面dom被隐藏的问题。
解决方法：在配置的路由参数和实际路由做比较的时候，将实际路由转化为小写。

<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/alitajs/alita/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/alitajs/alita/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/alitajs/alita/ISSUE_URL
