### PR TITLE
fix: keep alive error on convention routing

### DIFF
--- a/packages/keep-alive/src/utils/getModelContent.tsx
+++ b/packages/keep-alive/src/utils/getModelContent.tsx
@@ -1,4 +1,6 @@
 export default () => `
+import pathToRegexp from 'path-to-regexp';
+
 interface LayoutInstanceProps {
   alivePathnames:string[],
   keepAliveViewMap:{}
@@ -11,7 +13,12 @@ function dropByCacheKey(pathname: string) {
     if (index !== -1) {
       alivePathnames.splice(index, 1);
       // 用来当作key，只有key发生变化才会remout组件
-      keepAliveViewMap[pathname].recreateTimes += 1;
+      for (const key in keepAliveViewMap) {
+        if (pathToRegexp(key).test(pathname)) {
+          keepAliveViewMap[key].recreateTimes += 1;
+          break;
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/alitajs/alita/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/alitajs/alita/blob/master/CONTRIBUTING.md
-->
修复 keep alive 在动态路由的时候，清空缓存错误问题
![12121](https://user-images.githubusercontent.com/11746742/119917120-7abbe300-bf98-11eb-895c-5b52d81f702d.gif)

有个怪异行为，当动态路由被执行清楚时，会清楚所有的动态路由，这是由于在 react router 中，动态路由用的是同一个组件导致的。要解决的话可以把组件 clone 出来，但是这里没有处理这个事奇怪。

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/alitajs/alita/issues/186
