### PR TITLE
fix: export types

### DIFF
--- a/packages/alita/src/features/umiExports.ts
+++ b/packages/alita/src/features/umiExports.ts
@@ -1,3 +1,4 @@
+import { winPath } from '@umijs/utils';
 import { existsSync, readdirSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { AlitaApi } from '../types';
@@ -35,7 +36,7 @@ export default function (api: AlitaApi) {
         if (!existsSync(join(api.paths.absTmpPath, plugin, 'types.d.ts'))) {
           continue;
         }
-        file = join(api.paths.absTmpPath, plugin, 'types.d');
+        file = winPath(join(api.paths.absTmpPath, plugin, 'types.d'));
         exports.push(`export * from '${file}';`);
       }
 


### PR DESCRIPTION
```
error - D:downloadalita3appsrc.umiplugin-dva    ypes.d
Module build failed: UnhandledSchemeError: Reading from "D:downloadalita3appsrc.umiplugin-dva   ypes.d" is not handled by plugins (Unhandled scheme).
```