### PR TITLE
fix: mobile icons no find

### DIFF
--- a/.changeset/unlucky-fireants-shout.md
+++ b/.changeset/unlucky-fireants-shout.md
@@ -1,0 +1,5 @@
+---
+'@alita/plugins': patch
+---
+
+fix: mobile icons no find

--- a/packages/plugins/src/mobile-layout.ts
+++ b/packages/plugins/src/mobile-layout.ts
@@ -47,6 +47,9 @@ export default (api: AlitaApi) => {
         alitarequest: winPath(
           dirname(require.resolve('@alita/request/package')),
         ),
+        mobileicons: winPath(
+          dirname(require.resolve('antd-mobile-icons/package')),
+        ),
         hasKeepAlive: !!api.userConfig.keepalive,
         isMicroApp,
       }),

--- a/packages/plugins/templates/mobile-layout/layout5.tpl
+++ b/packages/plugins/templates/mobile-layout/layout5.tpl
@@ -22,7 +22,7 @@ import { useKeepOutlets } from '../plugin-keepalive/context';
 {{/hasKeepAlive}}
 
 import { NavBar, TabBar } from 'antd-mobile';
-import { LeftOutline } from 'antd-mobile-icons'
+import { LeftOutline } from '{{{ mobileicons }}}'
 
 export interface NavBarListItem {
     pagePath: string;


### PR DESCRIPTION
```bash
error - AssertionError [ERR_ASSERTION]: filePath not found of antd-mobile-icons
    at Dep.<anonymous> (/Users/congxiaochen/Documents/app-bill/node_modules/.pnpm/@umijs+mfsu@4.0.0-rc.6/node_modules/@umijs/mfsu/dist/dep/dep.js:67:34)
    at Generator.next (<anonymous>)
    at fulfilled (/Users/congxiaochen/Documents/app-bill/node_modules/.pnpm/@umijs+mfsu@4.0.0-rc.6/node_modules/@umijs/mfsu/dist/dep/dep.js:5:58)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5) {
  generatedMessage: false,
  code: 'ERR_ASSERTION',
  actual: null,
  expected: true,
  operator: '=='
}
```