### PR TITLE
docs: fix keepalive demo tag name

### DIFF
--- a/docs/docs/api/config.md
+++ b/docs/docs/api/config.md
@@ -108,7 +108,7 @@ const BasicLayout: React.FC<BasicLayoutProps> = props => {
   return (
     <OtherLayout>
       <KeepAliveLayout {...props}>{children}</KeepAliveLayout>
-    </AlitaLayout>
+    </OtherLayout>
   );
 };
 


### PR DESCRIPTION
修复下keepalive配置中的示例的OtherLayout的结束标签，与开始标签不一致