### PR TITLE
解决getCustomTabs重复渲染问题 ,tabsLayout增加对initialState的支持

### DIFF
--- a/packages/plugins/src/keepalive.ts
+++ b/packages/plugins/src/keepalive.ts
@@ -50,6 +50,7 @@ export default (api: AlitaApi) => {
       content: Mustache.render(contextTpl, {
         hasTabsLayout: !!tabsLayout,
         hasCustomTabs: !!tabsLayout?.hasCustomTabs,
+        isPluginModelEnable: api.isPluginEnable('model'),
       }),
     });
     const runtimeTpl = readFileSync(


### PR DESCRIPTION
1, 增加对initialState的支持
export const tabsLayout = ({initialState}) => { ... };

2, 修复getCustomTabs生成的Tabs, 每次对tab的切换都会导致整体被重复渲染的问题
const CustomTabs = React.useMemo(()=>getCustomTabs(), []);