### PR TITLE
fix(doc): config 排版问题

### DIFF
--- a/docs/docs/config/config.md
+++ b/docs/docs/config/config.md
@@ -123,6 +123,7 @@ const Layout: FC = () => {
 };
 
 export default Layout;
+```
 
 ### mainPath
 


### PR DESCRIPTION
修复config的配置文档排版文档
![image](https://user-images.githubusercontent.com/12181423/194764611-4ac19849-812d-4c8a-ade4-29cbf13e9d26.png)
