### PR TITLE
feat: support import drop from alita

### DIFF
--- a/.changeset/bright-jokes-wink.md
+++ b/.changeset/bright-jokes-wink.md
@@ -1,0 +1,5 @@
+---
+'@alita/plugins': patch
+---
+
+feat: support import drop from alita

--- a/packages/plugins/src/keepalive.ts
+++ b/packages/plugins/src/keepalive.ts
@@ -70,13 +70,26 @@ export default (api: AlitaApi) => {
         hasGetKeepalive: api.appData.appJS?.exports.includes('getKeepAlive'),
       }),
     });
-
+    api.writeTmpFile({
+      path: `${DIR_NAME}/support.tsx`,
+      noPluginDir: true,
+      content: `
+import { keepaliveEmitter } from './context';
+      
+export function dropByCacheKey(path: string) {
+  keepaliveEmitter.emit({type:'dropByCacheKey', payload: {
+    path
+  }});
+}
+`,
+    });
     // index.ts for export
     api.writeTmpFile({
       noPluginDir: true,
       path: `${DIR_NAME}/index.tsx`,
       content: `
 export { KeepAliveContext,useKeepOutlets } from './context';
+export {dropByCacheKey} from './support';
 `,
     });
   });

--- a/packages/plugins/src/keepalive.ts
+++ b/packages/plugins/src/keepalive.ts
@@ -89,7 +89,7 @@ export function dropByCacheKey(path: string) {
       path: `${DIR_NAME}/index.tsx`,
       content: `
 export { KeepAliveContext,useKeepOutlets } from './context';
-export {dropByCacheKey} from './support';
+export { dropByCacheKey } from './support';
 `,
     });
   });

--- a/packages/plugins/templates/keepalive/context.tpl
+++ b/packages/plugins/templates/keepalive/context.tpl
@@ -236,13 +236,13 @@ export function useKeepOutlets() {
     } = React.useContext(KeepAliveContext);
       
   keepaliveEmitter?.useSubscription?.((event) => {
-    const {type='',payload={}} = event;
+    const { type = '', payload = {} } = event;
     switch(type){
       case 'dropByCacheKey':
         dropByCacheKey(payload?.path);
         break;
-        default:
-          break;
+      default:
+        break;
     }
   });
     const isKeep = isKeepPath(keepalive, location.pathname, routeConfig);
@@ -250,7 +250,7 @@ export function useKeepOutlets() {
       const currentIndex = Object.keys(keepElements.current).length;
       {{#hasTabsLayout}}
       let icon = getMatchPathName(location.pathname, localConfig.icon);
-      if(typeof icon === 'string') icon ='';
+      if(typeof icon === 'string') icon = '';
 
       const defaultName = getMatchPathName(location.pathname, localConfig.local);
       // 国际化使用 pro 的约定


### PR DESCRIPTION
在 alita 3 中支持两种方式引用 dropByCacheKey

```
import { dropByCacheKey } from 'alita'; 
```

```
import { KeepAliveContext } from 'alita';
const { dropByCacheKey } = React.useContext<any>(KeepAliveContext); 
```

https://github.com/alitajs/alita/pull/461