### PR TITLE
fix(keepalive): 修复点击标签切换页面时query和hash丢失

### DIFF
--- a/.changeset/lazy-lizards-pull.md
+++ b/.changeset/lazy-lizards-pull.md
@@ -1,0 +1,5 @@
+---
+'@alita/plugins': major
+---
+
+修复点击标签切换页面时 query 和 hash 丢失

--- a/packages/plugins/templates/keepalive/context.tpl
+++ b/packages/plugins/templates/keepalive/context.tpl
@@ -234,7 +234,7 @@ export function useKeepOutlets() {
       dropOtherTabs,
       refreshTab,
     } = React.useContext(KeepAliveContext);
-      
+
   keepaliveEmitter?.useSubscription?.((event) => {
     const { type = '', payload = {} } = event;
     switch(type){
@@ -259,11 +259,11 @@ export function useKeepOutlets() {
       keepElements.current[location.pathname] = {
         children: element,
         index: currentIndex,
-        location,
         {{#hasTabsLayout}}
         name,
         icon,
         closable: true, // 默认是true
+        location,
         {{/hasTabsLayout}}
       };
     }

--- a/packages/plugins/templates/keepalive/context.tpl
+++ b/packages/plugins/templates/keepalive/context.tpl
@@ -259,6 +259,7 @@ export function useKeepOutlets() {
       keepElements.current[location.pathname] = {
         children: element,
         index: currentIndex,
+        location,
         {{#hasTabsLayout}}
         name,
         icon,
@@ -333,7 +334,8 @@ export function useKeepOutlets() {
               hideAdd
               onChange={(key: string) => {
                 const path = key.split(':')[0];
-                navigate(path);
+                const { pathname, hash, search } = keepElements.current[path].location;
+                navigate(`${pathname}${search}${hash}`);
               }}
               activeKey={`${location.pathname}::${tabNameMap[location.pathname]}`}
               type="editable-card"


### PR DESCRIPTION
增加了location参数以解决点击标签切页面时路径会丢失query和hash的问题

**存在的问题**：直接修改路径hash不会刷新页面所以keepElements并不能同步的修改，导致keepElements里的hash还是上一次的值