### PR TITLE
fix: 修复截断key处bug

### DIFF
--- a/.changeset/honest-spies-juggle.md
+++ b/.changeset/honest-spies-juggle.md
@@ -1,0 +1,5 @@
+---
+'@alita/plugins': patch
+---
+
+修复截断 key 处 bug

--- a/packages/plugins/templates/keepalive/context.tpl
+++ b/packages/plugins/templates/keepalive/context.tpl
@@ -406,7 +406,7 @@ export function useKeepOutlets() {
 {{/hasDropdown}}
               hideAdd
               onChange={(key: string) => {
-                const path = key.split(':')[0];
+                const path = key.split('::')[0];
                 const { pathname, hash, search } = keepElements.current[path?.toLowerCase()].location;
                 navigate(`${pathname}${search}${hash}`);
               }}


### PR DESCRIPTION
下面拼接key的逻辑是用双冒号:: 来做的，所以在onChange的时候split也应该是双冒号