### PR TITLE
fix: replace includes check with instanceof RegExp

### DIFF
--- a/.changeset/wicked-walls-marry.md
+++ b/.changeset/wicked-walls-marry.md
@@ -1,0 +1,5 @@
+---
+'@alita/plugins': patch
+---
+
+replace includes check with instanceof RegExp

--- a/packages/plugins/src/hd.ts
+++ b/packages/plugins/src/hd.ts
@@ -72,7 +72,7 @@ export default (api: AlitaApi) => {
         // 将正则转成字符串
         selectorDoubleList: px2remConfig.selectorDoubleRemList.map(
           (i: string) => {
-            if (!i.includes('/')) return i;
+            if (!(i instanceof RegExp)) return i;
             const reStr = `${i}`.replaceAll('/', '');
             if (hasMagicChars(reStr)) {
               return reStr;


### PR DESCRIPTION
```bash
fatal - TypeError: i.includes is not a function
```

```js
hd: {
    px2rem: {
      rootValue: 100,
      minPixelValue: 2,
      selectorDoubleRemList: [/^.adm-/, /^.ant-/, /^\:root/],
    },
  },
mako: {},
```

